### PR TITLE
add @brigadecore/blog-maintainers as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
-# Global Owners: These members are Core Maintainers of Brigade
-* @brigadecore/maintainers
+# Global Owners: These are brigadecore org maintainers + maintainers of this repo
+* @brigadecore/maintainers @brigadecore/blog-maintainers


### PR DESCRIPTION
This PR adds the `@brigadecore/blog-maintainers` group as owners of the repo, with intentions of soon nominating additional repo-level maintainers.