### PR TITLE
add permissive cors header for rss feed

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/index.xml"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
I'm working on a v2-compatible replacement for Kashti and I want to put a card on the home page that shows the headline and teaser text from the latest blog post, but CORS is getting in the way.

I _think_ this PR will fix that.