### PR TITLE
update netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,13 @@
+[build]
+  publish = "public/"
+  command = "hugo"
+
+[build.environment]
+  HUGO_VERSION = "0.92.0"
+  
+[context.deploy-preview]
+  command = "hugo -b $DEPLOY_PRIME_URL"
+
 [[headers]]
   for = "/index.xml"
   [headers.values]


### PR DESCRIPTION
These new rules in `netlify.toml` should eliminate the problem of links on the preview sites going out to the production site. i.e. The preview site will become navigable. It really hasn't been prior to this.