### PR TITLE
Add project-archived banner

### DIFF
--- a/assets/scss/brigade.scss
+++ b/assets/scss/brigade.scss
@@ -21,6 +21,24 @@ $work: 'work_sansregular', 'Helvetica Neue', Helvetica, Arial, Geneva, sans-seri
 }
 
 // Layout
+
+.banner {
+  background: #dc3545;
+  color: #ffffff;
+  font-size: 0.925em;
+  line-height: 1;
+  padding: 0.75em 0 1.25em;
+  text-align: center;
+  a {
+    color: #ffffff;
+    text-decoration: underline;
+  }
+  h4 {
+    color: #ffffff;
+    font-size: 140%;
+  }
+}
+
 .nav {
   background: $boxl;
   background: -webkit-linear-gradient(left, $boxl, $boxd);
@@ -78,7 +96,7 @@ main {
       color: $colord;
       font-family: $work;
     }
-    
+
     p {
       color: $text;
       line-height: 2;
@@ -141,7 +159,7 @@ main {
       margin-left: auto;
       margin-right: auto;
     }
-  
+
     ul {
       display: none;
     }

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,18 @@
+<section class="banner">
+  <h4>The Brigade project is <a href="https://www.cncf.io/archived-projects">archived</a>.
+    <a href="https://github.com/cncf/toc/pull/915">Learn&nbsp;more</a>.
+  </h4>
+</section>
+
+<nav class="nav">
+	<div class="nav-container">
+		<a href="{{ "/" | relURL }}">
+			{{ if .IsPage }}
+				<h2 class="nav-title">{{ .Site.Title }}</h2>
+			{{ else }}
+				<h1 class="nav-title">{{ .Site.Title }}</h1>
+			{{ end }}
+		</a>
+		{{ partial "header-menu.html" . }}
+	</div>
+</nav>


### PR DESCRIPTION
- Contributes to https://github.com/brigadecore/brigade/issues/1983
- Preview: https://deploy-preview-57--blog-brigade-sh.netlify.app/

### Screenshots

Desktop:

> <img width="833" alt="image" src="https://user-images.githubusercontent.com/4140793/192878504-636a19c6-41ba-4ac4-bf2c-01e0056bc346.png">

Mobile:

> <img width="375" alt="image" src="https://user-images.githubusercontent.com/4140793/192878430-e017e0e5-82a7-4b0f-b3da-d7fb4ac6f814.png">

This is what the doc-page banner looks like, in comparison:

> <img width="776" alt="image" src="https://user-images.githubusercontent.com/4140793/192878840-2a24efaf-de2d-40b1-b04b-b635c4623d40.png">
